### PR TITLE
CRM_Rebook_Legacycode_OptionGroup: Don't throw exception if OptionValue isn't found

### DIFF
--- a/CRM/Rebook/Legacycode/OptionGroup.php
+++ b/CRM/Rebook/Legacycode/OptionGroup.php
@@ -49,11 +49,17 @@ class CRM_Rebook_Legacycode_OptionGroup {
     }
 
     // build/run API query
-    $value = civicrm_api3('OptionValue', 'getvalue', [
-      'option_group_id' => $group_name,
-      $label_field => $label,
-      'return' => $value_field
-    ]);
+    try {
+      $value = civicrm_api3('OptionValue', 'getvalue', [
+        'option_group_id' => $group_name,
+        $label_field => $label,
+        'return' => $value_field
+      ]);
+    }
+    catch (CRM_Core_Exception $e) {
+      // OptionValue not found.
+      return NULL;
+    }
 
     // anything else to do here?
     return (string) $value;


### PR DESCRIPTION
The former code in CiviCRM Core also doesn't throw an exception.